### PR TITLE
 Add hold-to-fire for countermeasure controls

### DIFF
--- a/NO_Tactitools/src/Controls/CountermeasureControl.cs
+++ b/NO_Tactitools/src/Controls/CountermeasureControl.cs
@@ -1,5 +1,6 @@
 using System;
 using HarmonyLib;
+using Rewired;
 using NO_Tactitools.Core;
 
 namespace NO_Tactitools.Controls;
@@ -7,8 +8,7 @@ namespace NO_Tactitools.Controls;
 [HarmonyPatch(typeof(MainMenu), "Start")]
 class CountermeasureControlsPlugin {
     private static bool initialized = false;
-    private static bool isFiringFlare = false;
-    private static bool isFiringJammer = false;
+    private static bool isFiring = false;
 
     static void Postfix() {
         if (!initialized) {
@@ -18,16 +18,16 @@ class CountermeasureControlsPlugin {
                 0.01f,
                 onRelease: HandleSelectFlare,
                 onLongPress: HandleLongPressFlare,
-                onAnyRelease: () => { isFiringFlare = false; }
+                onAnyRelease: HandleAnyRelease
             );
             InputCatcher.RegisterNewInput(
                 Plugin.countermeasureControlsJammer,
                 0.01f,
                 onRelease: HandleSelectJammer,
                 onLongPress: HandleLongPressJammer,
-                onAnyRelease: () => { isFiringJammer = false; }
+                onAnyRelease: HandleAnyRelease
             );
-            Plugin.harmony.PatchAll(typeof(CountermeasureFirePatch));
+            Plugin.harmony.PatchAll(typeof(SimulateCountermeasurePress));
             initialized = true;
             Plugin.Log("[CC] Countermeasure Controls plugin succesfully started !");
         }
@@ -45,22 +45,28 @@ class CountermeasureControlsPlugin {
     private static void HandleLongPressFlare() {
         GameBindings.Player.Aircraft.Countermeasures.SetIRFlare();
         if (Plugin.countermeasureControlsFireOnHold.Value)
-            isFiringFlare = true;
+            isFiring = true;
     }
 
     private static void HandleLongPressJammer() {
         if (GameBindings.Player.Aircraft.Countermeasures.HasJammer()) {
             GameBindings.Player.Aircraft.Countermeasures.SetJammer();
             if (Plugin.countermeasureControlsFireOnHold.Value)
-                isFiringJammer = true;
+                isFiring = true;
         }
     }
 
-    [HarmonyPatch(typeof(CombatHUD), "FixedUpdate")]
-    static class CountermeasureFirePatch {
-        static void Postfix() {
-            if (isFiringFlare || isFiringJammer)
-                GameBindings.Player.Aircraft.Countermeasures.FireCountermeasure();
+    private static void HandleAnyRelease() {
+        isFiring = false;
+    }
+
+    // Makes the game's own countermeasure input logic believe its native button
+    // is held, so the full vanilla firing/jamming path runs unmodified.
+    [HarmonyPatch(typeof(Rewired.Player), "GetButton", typeof(string))]
+    static class SimulateCountermeasurePress {
+        static void Postfix(string actionName, ref bool __result) {
+            if (isFiring && actionName == "Countermeasures")
+                __result = true;
         }
     }
 }

--- a/NO_Tactitools/src/Controls/CountermeasureControl.cs
+++ b/NO_Tactitools/src/Controls/CountermeasureControl.cs
@@ -15,14 +15,14 @@ class CountermeasureControlsPlugin {
             Plugin.Log($"[CC] Countermeasure Controls plugin starting !");
             InputCatcher.RegisterNewInput(
                 Plugin.countermeasureControlsFlare,
-                0.3f,
+                0.01f,
                 onRelease: HandleSelectFlare,
                 onLongPress: HandleLongPressFlare,
                 onAnyRelease: () => { isFiringFlare = false; }
             );
             InputCatcher.RegisterNewInput(
                 Plugin.countermeasureControlsJammer,
-                0.3f,
+                0.01f,
                 onRelease: HandleSelectJammer,
                 onLongPress: HandleLongPressJammer,
                 onAnyRelease: () => { isFiringJammer = false; }

--- a/NO_Tactitools/src/Controls/CountermeasureControl.cs
+++ b/NO_Tactitools/src/Controls/CountermeasureControl.cs
@@ -7,32 +7,60 @@ namespace NO_Tactitools.Controls;
 [HarmonyPatch(typeof(MainMenu), "Start")]
 class CountermeasureControlsPlugin {
     private static bool initialized = false;
+    private static bool isFiringFlare = false;
+    private static bool isFiringJammer = false;
 
     static void Postfix() {
         if (!initialized) {
             Plugin.Log($"[CC] Countermeasure Controls plugin starting !");
             InputCatcher.RegisterNewInput(
                 Plugin.countermeasureControlsFlare,
-                0.0001f, 
-                onLongPress: HandleOnHoldFlare
-                );
+                0.3f,
+                onRelease: HandleSelectFlare,
+                onLongPress: HandleLongPressFlare,
+                onAnyRelease: () => { isFiringFlare = false; }
+            );
             InputCatcher.RegisterNewInput(
                 Plugin.countermeasureControlsJammer,
-                0.0001f,
-                onLongPress: HandleOnHoldJammer
-                );
+                0.3f,
+                onRelease: HandleSelectJammer,
+                onLongPress: HandleLongPressJammer,
+                onAnyRelease: () => { isFiringJammer = false; }
+            );
+            Plugin.harmony.PatchAll(typeof(CountermeasureFirePatch));
             initialized = true;
             Plugin.Log("[CC] Countermeasure Controls plugin succesfully started !");
         }
     }
 
-    private static void HandleOnHoldFlare() {
+    private static void HandleSelectFlare() {
         GameBindings.Player.Aircraft.Countermeasures.SetIRFlare();
     }
 
-    private static void HandleOnHoldJammer() {
+    private static void HandleSelectJammer() {
         if (GameBindings.Player.Aircraft.Countermeasures.HasJammer())
             GameBindings.Player.Aircraft.Countermeasures.SetJammer();
     }
-}
 
+    private static void HandleLongPressFlare() {
+        GameBindings.Player.Aircraft.Countermeasures.SetIRFlare();
+        if (Plugin.countermeasureControlsFireOnHold.Value)
+            isFiringFlare = true;
+    }
+
+    private static void HandleLongPressJammer() {
+        if (GameBindings.Player.Aircraft.Countermeasures.HasJammer()) {
+            GameBindings.Player.Aircraft.Countermeasures.SetJammer();
+            if (Plugin.countermeasureControlsFireOnHold.Value)
+                isFiringJammer = true;
+        }
+    }
+
+    [HarmonyPatch(typeof(CombatHUD), "FixedUpdate")]
+    static class CountermeasureFirePatch {
+        static void Postfix() {
+            if (isFiringFlare || isFiringJammer)
+                GameBindings.Player.Aircraft.Countermeasures.FireCountermeasure();
+        }
+    }
+}

--- a/NO_Tactitools/src/Core/GameBindings.cs
+++ b/NO_Tactitools/src/Core/GameBindings.cs
@@ -236,13 +236,6 @@ public class GameBindings {
                     catch (NullReferenceException e) { Plugin.Log(e.ToString()); }
                 }
 
-                public static void FireCountermeasure() {
-                    try {
-                        global::Aircraft aircraft = SceneSingleton<CombatHUD>.i.aircraft;
-                        aircraft.countermeasureManager.DeployCountermeasure(aircraft);
-                    }
-                    catch (NullReferenceException e) { Plugin.Log(e.ToString()); }
-                }
             }
 
             public class Weapons {

--- a/NO_Tactitools/src/Core/GameBindings.cs
+++ b/NO_Tactitools/src/Core/GameBindings.cs
@@ -235,6 +235,14 @@ public class GameBindings {
                     }
                     catch (NullReferenceException e) { Plugin.Log(e.ToString()); }
                 }
+
+                public static void FireCountermeasure() {
+                    try {
+                        global::Aircraft aircraft = SceneSingleton<CombatHUD>.i.aircraft;
+                        aircraft.countermeasureManager.DeployCountermeasure(aircraft);
+                    }
+                    catch (NullReferenceException e) { Plugin.Log(e.ToString()); }
+                }
             }
 
             public class Weapons {

--- a/NO_Tactitools/src/Core/InputCatcher.cs
+++ b/NO_Tactitools/src/Core/InputCatcher.cs
@@ -14,6 +14,7 @@ public class InputRegistration {
     public System.Action onShortPress;
     public System.Action onHold;
     public System.Action onLongPress;
+    public System.Action onAnyRelease;
 }
 
 public class InputCatcher {
@@ -28,15 +29,17 @@ public class InputCatcher {
         float longPressThreshold = 0.2f,
         System.Action onRelease = null,
         System.Action onHold = null,
-        System.Action onLongPress = null
+        System.Action onLongPress = null,
+        System.Action onAnyRelease = null
         ) {
-        
+
         InputRegistration reg = new() {
             config = config,
             longPressThreshold = longPressThreshold,
             onShortPress = onRelease,
             onHold = onHold,
-            onLongPress = onLongPress
+            onLongPress = onLongPress,
+            onAnyRelease = onAnyRelease
         };
         allRegistrations.Add(reg);
 
@@ -90,7 +93,7 @@ public class InputCatcher {
             TryRegisterOrQueue(reg, controllerName, buttonIndex);
         }
     }
-    
+
     public static void ModifyInputAfterNewConfig(RewiredInputConfig config) {
         UnregisterInput(config);
         RegisterNewBinding(config);
@@ -161,7 +164,7 @@ public class ControllerInput {
         this.buttonPressTime = Time.time;
         this.longPressHandled = true; // Assume it's already handled if they're holding it down on registration
         this.holdLongHandled = true;
-        if (registration.onShortPress == null && registration.onLongPress == null && registration.onHold == null) {
+        if (registration.onShortPress == null && registration.onLongPress == null && registration.onHold == null && registration.onAnyRelease == null) {
             Plugin.Logger.LogError("[IC] No actions provided for button " + buttonNumber);
         }
         else {
@@ -215,12 +218,13 @@ class ControllerInputInterceptionPatch {
                                 button.registration.onHold?.Invoke();
                             }
                         }
-                        else if (button.previousButtonState && !button.currentButtonState && button.registration.onShortPress != null) {
+                        else if (button.previousButtonState && !button.currentButtonState) {
                             // Button just released
-                            if (!button.longPressHandled) {
+                            if (!button.longPressHandled && button.registration.onShortPress != null) {
                                 Plugin.Log($"[IC] Short press detected on button {button.buttonNumber.ToString()}");
                                 button.registration.onShortPress?.Invoke();
                             }
+                            button.registration.onAnyRelease?.Invoke();
                         }
                         button.previousButtonState = button.currentButtonState;
                     }

--- a/NO_Tactitools/src/Core/Plugin.cs
+++ b/NO_Tactitools/src/Core/Plugin.cs
@@ -25,6 +25,7 @@ namespace NO_Tactitools.Core {
         public static ConfigEntry<bool> targetListControllerEnabled;
         public static ConfigEntry<bool> interceptionVectorEnabled;
         public static ConfigEntry<bool> countermeasureControlsEnabled;
+        public static ConfigEntry<bool> countermeasureControlsFireOnHold;
         public static RewiredInputConfig countermeasureControlsFlare;
         public static RewiredInputConfig countermeasureControlsJammer;
         public static ConfigEntry<bool> weaponSwitcherEnabled;
@@ -128,6 +129,15 @@ namespace NO_Tactitools.Core {
                     null,
                     new ConfigurationManagerAttributes {
                         Order = 4
+                    }));
+            countermeasureControlsFireOnHold = Config.Bind("Countermeasures",
+                "Countermeasure Controls - Fire On Hold",
+                true,
+                new ConfigDescription(
+                    "When enabled, holding the flare or jammer button will also fire that countermeasure.",
+                    null,
+                    new ConfigurationManagerAttributes {
+                        Order = 2
                     }));
             countermeasureControlsFlare = new RewiredInputConfig(Config, "Countermeasures", "Countermeasure Controls - Flares", "Input you want to assign for selecting Flares", 2);
             countermeasureControlsJammer = new RewiredInputConfig(Config, "Countermeasures", "Countermeasure Controls - Jammer", "Input you want to assign for selecting Jammer", 0);


### PR DESCRIPTION
## Summary

- Holding the flare or jammer button now also fires that countermeasure continuously until released
- A new **Fire On Hold** toggle in the `Countermeasures` config section lets users disable firing while keeping the selection bindings

## Changes

**`InputCatcher.cs` / `InputRegistration`**
Added an `onAnyRelease` callback that fires on every key-up regardless of press duration. Needed to reliably clear the firing state on long-press release, since `onShortPress` is suppressed after a long press. Backwards-compatible — existing registrations that do not pass it have it as `null`.

**`GameBindings.cs`**
Added `FireCountermeasure()` to `GameBindings.Player.Aircraft.Countermeasures`, calling `CountermeasureManager.DeployCountermeasure(aircraft)` directly — the same path the game takes each `FixedUpdate` frame when the player holds their countermeasure button. Uses `global::Aircraft` to avoid the name clash with the nested `GameBindings.Player.Aircraft` class.

**`CountermeasureControl.cs`**
Restructured input registration with a 0.01s long-press threshold: `onRelease` (tap) selects only; `onLongPress` (hold) selects and sets a firing flag if Fire On Hold is enabled; `onAnyRelease` always clears the flag. A new inner `CountermeasureFirePatch` on `CombatHUD.FixedUpdate` calls `FireCountermeasure()` each physics frame while the flag is set. Rate limiting is handled internally by `FlareEjector`.

**`Plugin.cs`**
Added `countermeasureControlsFireOnHold` config entry under the `Countermeasures` category.

## Reviewer notes

- `DeployCountermeasure` is called every `FixedUpdate` frame while held — safe because `FlareEjector.Fire()` gates on its own ejection interval internally
- The `onAnyRelease` addition to `InputCatcher` is backwards-compatible with all existing input registrations