### PR TITLE
Weapon swap turret manual/auto mode desync fix + two unknown characters in TMP font for intercept progress bar replacement

### DIFF
--- a/NO_Tactitools/src/Core/GameBindings.cs
+++ b/NO_Tactitools/src/Core/GameBindings.cs
@@ -338,13 +338,21 @@ public class GameBindings {
                 }
 
                 public static void SetActiveStation(byte index) {
-                    try {
-                        if (index < GetStationCount()) {
-                            SceneSingleton<CombatHUD>.i.aircraft.weaponManager.SetActiveStation(index);
-                            SceneSingleton<CombatHUD>.i.ShowWeaponStation(SceneSingleton<CombatHUD>.i.aircraft.weaponManager.currentWeaponStation);
+                    try
+                    {
+                        global::Aircraft aircraft = GetAircraft();
+                        
+                        if (aircraft == null)
+                            return;
+                        
+                        if (index >= aircraft.weaponStations.Count)
+                        {
+                            Plugin.Log($"[BD] Station index {index} out of range!");
+                            return;
                         }
-                        else
-                            Plugin.Log("[BD] Station index out of range !");
+                        
+                        aircraft.SetActiveStation(index);
+                        SceneSingleton<CombatHUD>.i.ShowWeaponStation(aircraft.weaponStations[index]);
                     }
                     catch (NullReferenceException e) { Plugin.Log(e.ToString()); }
                 }

--- a/NO_Tactitools/src/UI/MFD/InterceptionVector.cs
+++ b/NO_Tactitools/src/UI/MFD/InterceptionVector.cs
@@ -236,7 +236,7 @@ class InterceptionVectorTask {
             float progress = (float)interceptArray.Count / interceptArraySize;
             int barLength = 12;
             int filledCount = (int)(progress * (barLength+1));
-            string bar = new string('█', filledCount).PadRight(barLength, '░');
+            string bar = new string('|', filledCount).PadRight(barLength, '.');
             timerLabel.SetText(bar);
 
             string scrambled = "";


### PR DESCRIPTION
This swaps the weapon swap logic from directly calling `aircraft.weaponManager.SetActiveStation(index)`, to doing it via `aircraft.SetActiveStation(index)` - this is how the vanilla Weapon Wheel does it too, and this is important as that previous step is also what interfaces with client => server communication via `RpcSetActiveStation(stationIndex);` / `CmdSetActiveStation(stationIndex);`.

This fixes a desync that can happen when playing as client on server, where if you swap to a turreted weapon with NOTT direct keybind, it'll not be in manual mode on server, so your aim is constantly being overridden/fought by the turret trying to auto aim via its Turret.cs manual mode check, and bounce back and forth.

Also swapped the progress bar in the interception vector to a simpler looking one that has the characters available, as the previous squares unfortunately weren't, so they were displayed as hollow placeholder squares and every frame during this it printed warnings in logs.